### PR TITLE
Fix zenodo link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ pip install -r requirements.txt
 ```
 
 ## Trained models
-Download and extract trained models from https://zenodo.org/deposit/8313466.
+Download and extract trained models from https://zenodo.org/record/8313466
 ```
 tar -xvzf model.tar.gz
 ```


### PR DESCRIPTION
Zenodo link is not pointing to the public version of the record